### PR TITLE
Refactor detailed output structure and enhance result UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -819,17 +819,14 @@ def resultado_opcion2():
     # Crear la nueva representación de frecuencias para cada palabra
     salida_detallada = []
     for palabra_actual, datos in frecuencias_por_palabra.items():
-        letras_con_valores = [
-            f"{letra.upper()}={valor}" for letra, valor in zip(palabra_actual, datos["frecuencia_por_letra"])
-        ]
-        # Formatear la palabra o frase en negrita
-        palabra_formateada = f"<strong>{palabra_actual}</strong>: [ {', '.join(letras_con_valores)} ]"
-    
-        # Agregar "= suma" solo para frases con múltiples palabras
-        if len(frecuencias_por_palabra) > 1:
-            palabra_formateada += f" = {datos['suma']}"
-    
-        salida_detallada.append(palabra_formateada)
+        salida_detallada.append({
+            "palabra": palabra_actual,
+            "letras": [
+                {"char": letra.upper(), "valor": valor}
+                for letra, valor in zip(palabra_actual, datos["frecuencia_por_letra"])
+            ],
+            "suma": datos["suma"] if len(frecuencias_por_palabra) > 1 else None,
+        })
 
 
     # Verificar si hay más de una palabra

--- a/templates/resultado.html
+++ b/templates/resultado.html
@@ -46,17 +46,27 @@
             class="bg-white shadow-lg rounded-2xl p-6 border border-gray-300 hover:shadow-xl transition">
             <!-- Resultados formateados para la opción 2 -->
             <!-- Cada línea muestra una palabra analizada con su detalle -->
-            <ul class="mt-4 space-y-2">
-                {% for linea in salida_detallada %}
-                <li class="text-gray-600">
-                    <!-- 'safe' se usa para renderizar contenido HTML seguro (negritas en palabras) -->
-                    {{ linea|safe }}
+            <ul class="mt-4 space-y-4">
+                {% for item in salida_detallada %}
+                <li>
+                    <strong>{{ item.palabra|title }}</strong>
+                    <div class="flex flex-wrap gap-2 mt-2">
+                        {% for par in item.letras %}
+                        <span class="px-2 py-1 bg-gray-200 rounded-md">{{ par.char }} = {{ par.valor }}</span>
+                        {% endfor %}
+                    </div>
+                    {% if item.suma %}<div class="mt-2 font-semibold">= {{ item.suma }}</div>{% endif %}
                 </li>
                 {% endfor %}
             </ul>
-            <!-- Total y lupa de la frase analizada -->
-            <p class="mt-4 text-gray-600"><strong>Total:</strong> {{ total }}</p>
-            <p class="mt-4 text-gray-600"><strong>Lupa:</strong> {{ lupa }}</p>
+        </div>
+        <div class="bg-white shadow-lg rounded-2xl p-6 border border-gray-300 hover:shadow-xl transition">
+            <p class="text-gray-600 font-semibold">Total</p>
+            <p class="mt-2 text-2xl text-gray-800">{{ total }}</p>
+        </div>
+        <div class="bg-white shadow-lg rounded-2xl p-6 border border-gray-300 hover:shadow-xl transition">
+            <p class="text-gray-600 font-semibold">Lupa</p>
+            <p class="mt-2 text-2xl text-gray-800">{{ lupa }}</p>
         </div>
     </div>
     {% elif opcion == 3 %}
@@ -388,8 +398,8 @@
                 } else {
                     // Crear un array con cada línea de salida_detallada
                     const salidaArray = [
-                        {% for linea in salida_detallada %}
-                        "{{ linea | striptags }}",
+                        {% for item in salida_detallada %}
+                        "{{ item.palabra|title|escapejs }}: {% for par in item.letras %}{{ par.char }}={{ par.valor }}{% if not loop.last %}, {% endif %}{% endfor %}{% if item.suma %} = {{ item.suma }}{% endif %}",
                         {% endfor %}
                     ];
                     
@@ -473,8 +483,8 @@
                 } else {
                     // Crear un array con cada línea de salida_detallada
                     const salidaArray = [
-                        {% for linea in salida_detallada %}
-                        "*{{ linea | striptags }}*",
+                        {% for item in salida_detallada %}
+                        "*{{ item.palabra|title|escapejs }}: {% for par in item.letras %}{{ par.char }}={{ par.valor }}{% if not loop.last %}, {% endif %}{% endfor %}{% if item.suma %} = {{ item.suma }}{% endif %}*",
                         {% endfor %}
                     ];
                     


### PR DESCRIPTION
## Summary
- Replace string-based `salida_detallada` with list of objects for richer detail
- Render option 2 results iterating over letter objects and display Total/Lupa in separate cards
- Adjust copy/share scripts to consume new structured output

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1fad87b608323b2eb0d582a973a91